### PR TITLE
fix stack smashing crash for s3 test

### DIFF
--- a/src/acpi/s3/s3.c
+++ b/src/acpi/s3/s3.c
@@ -96,7 +96,8 @@ static int read_wakeup_source(fwts_list *source)
 	/* skip first line */
 	while (c = fgetc(fp), c != '\n' && c != EOF);
 
-	while (fscanf(fp, "%s\t%lu\t\t%lu\t\t%lu\t\t%lu\t\t%ld\t\t%ld\t\t%ld\t\t%ld\t\t%ld\n",
+	/* NB: important to specify the max len fscanf reads for name to avoid stack smashing */
+	while (fscanf(fp, "%31s\t%lu\t\t%lu\t\t%lu\t\t%lu\t\t%ld\t\t%ld\t\t%ld\t\t%ld\t\t%ld\n",
 			name, &active_count, &event_count,
 			&wakeup_count, &expire_count, &active_since,
 			&total_time, &max_time, &last_change,


### PR DESCRIPTION
when fwts parses /sys/kernel/debug/wakeup_sources, if this file has any entry with long name (>32), fwts can crash with error : *** stack smashing detected ***: terminated
this is a gcc stack smashing protection mechanism that is enabled with the flag -fstack-protection-strong

this commit fixes this issue by enforcing the max len of the field name fscanf can read from the wakeup_sources entries.