### PR TITLE
Apicedge tests fail on systems with large number of CPUs

### DIFF
--- a/src/apic/apicedge/apicedge.c
+++ b/src/apic/apicedge/apicedge.c
@@ -54,7 +54,7 @@ static int apicedge_test1(fwts_framework *fw)
 	}
 
 	while (!feof(file)) {
-		char line[4096], *c;
+		char line[8192], *c;
 		int edge = UNDEFINED;
 		int irq = 0;
 


### PR DESCRIPTION
The buffer to read the lines of /proc/interrupts is not long enough to read a full line, making the test fail. Duplicated the size of the buffer