### PR TITLE
Fix compilation with GCC 16

### DIFF
--- a/src/acpi/hest/hest.c
+++ b/src/acpi/hest/hest.c
@@ -786,8 +786,7 @@ static int hest_test1(fwts_framework *fw)
         ssize_t length = (ssize_t)hest->header.length;
 	uint32_t hest_type_00_count = 0,
 		 hest_type_01_count = 0,
-		 hest_type_02_count = 0,
-		 hest_type_11_count = 0;
+		 hest_type_02_count = 0;
 
 	if (!fwts_acpi_table_length(fw, "HEST", table->length, sizeof(fwts_acpi_table_hest))) {
 		passed = false;
@@ -835,7 +834,6 @@ static int hest_test1(fwts_framework *fw)
 		case 11:
 			/* the structure of type 11 is the same as type 1 */
 			hest_check_ia32_arch_corrected_machine_check(fw, &length, &data, &passed);
-			hest_type_11_count++;
 			break;
 		default:
 			fwts_failed(fw, LOG_LEVEL_HIGH,

--- a/src/lib/src/fwts_args.c
+++ b/src/lib/src/fwts_args.c
@@ -106,7 +106,6 @@ int fwts_args_parse(fwts_framework *fw, const int argc, char * const argv[])
 	int i;
 	int c;
 	int option_index;
-	int master_option_index;
 	int translated_long_option_index;
 	int ret = FWTS_OK;
 	char *short_options = NULL;
@@ -185,7 +184,6 @@ int fwts_args_parse(fwts_framework *fw, const int argc, char * const argv[])
 	}
 
 	for (;;) {
-		master_option_index = total_options;
 		translated_long_option_index = 0;
 		c = getopt_long(argc, argv, short_options, long_options, &option_index);
 		if (c == -1)
@@ -222,8 +220,6 @@ int fwts_args_parse(fwts_framework *fw, const int argc, char * const argv[])
 				if (ret != FWTS_OK)
 					goto exit;
 				break;
-			} else {
-				master_option_index -= options_table->num_options;
 			}
 
 		}

--- a/src/lib/src/fwts_framework.c
+++ b/src/lib/src/fwts_framework.c
@@ -319,7 +319,6 @@ static void fwts_framework_show_tests(fwts_framework *fw, const bool full)
 	fwts_list sorted;
 	int i;
 	bool need_nl = false;
-	int total = 0;
 
 	/* Dump out tests registered under all categories */
 	for (i = 0; categories[i].title != NULL; i++) {
@@ -355,7 +354,6 @@ static void fwts_framework_show_tests(fwts_framework *fw, const bool full)
 							test->ops->total_tests > 1 ? "s" : "");
 						for (j = 0; j < test->ops->total_tests; j++)
 							printf("  %s\n", test->ops->minor_tests[j].name);
-						total += test->ops->total_tests;
 					}
 					else {
 						printf(" %-15.15s %s\n", test->name,


### PR DESCRIPTION
GCC 16 seems to emit some additional warnings with regards to unused variables. Remove those to fix compilation with -Werror enabled.