### PR TITLE
Allow compilation without libbsd

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -85,6 +85,9 @@
 	    AC_DEFINE([HAVE_LIBPCI], [1], [Define if we have libpci])])
 	  AM_CONDITIONAL([HAVE_LIBPCI],
 	    [test "x$ac_cv_search_pci_alloc" != "xno"])
+	  AC_SEARCH_LIBS([strlcpy], [bsd],, AC_MSG_ERROR([strlcpy is not available]))
+	  AM_CONDITIONAL([HAVE_LIBBSD],
+	    [test "x$ac_cv_search_strlcpy" = "x-lbsd"])
 	  AC_FUNC_MALLOC
 	  AC_FUNC_FORK
 	  AC_FUNC_LSTAT_FOLLOWS_SLASHED_SYMLINK

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -230,8 +230,12 @@ fwts_SOURCES = main.c 				\
 
 fwts_LDFLAGS = -no-undefined
 
+if HAVE_LIBBSD
+fwts_LDADD_BSD = -lbsd
+endif
+
 fwts_LDADD = \
-	-lbsd \
+	$(fwts_LDADD_BSD) \
 	$(top_builddir)/src/lib/src/libfwts.la \
 	$(top_builddir)/src/libfwtsiasl/libfwtsiasl.la \
 	$(top_builddir)/src/libfwtsacpica/libfwtsacpica.la

--- a/src/acpi/crsdump/crsdump.c
+++ b/src/acpi/crsdump/crsdump.c
@@ -23,11 +23,14 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <bsd/string.h>
 #include <unistd.h>
 #include <inttypes.h>
 #include "fwts_acpi_object_eval.h"
 #include "crsdump.h"
+
+#ifdef HAVE_BSD_STRING_H
+#include <bsd/string.h>
+#endif
 
 typedef struct {
 	const char *label;				/* Field label */

--- a/src/acpi/uniqueid/uniqueid.c
+++ b/src/acpi/uniqueid/uniqueid.c
@@ -25,7 +25,10 @@
 #include <unistd.h>
 #include <inttypes.h>
 #include <string.h>
+
+#ifdef HAVE_BSD_STRING_H
 #include <bsd/string.h>
+#endif
 
 #include "fwts_acpi_object_eval.h"
 

--- a/src/cpu/maxfreq/maxfreq.c
+++ b/src/cpu/maxfreq/maxfreq.c
@@ -24,7 +24,10 @@
 #include <dirent.h>
 #include <ctype.h>
 #include <math.h>
+
+#ifdef HAVE_BSD_STRING_H
 #include <bsd/string.h>
+#endif
 
 #define CPU_FREQ_PATH	"/sys/devices/system/cpu"
 #define CPU_INFO_PATH	"/proc/cpuinfo"

--- a/src/lib/src/Makefile.am
+++ b/src/lib/src/Makefile.am
@@ -30,8 +30,13 @@ pkglib_LTLIBRARIES = libfwts.la
 
 libfwts_la_LDFLAGS = -version-info 1:0:0
 
+if HAVE_LIBBSD
+libfwts_LDADD_BSD = -lbsd
+endif
+
 libfwts_la_LIBADD = 				\
-	-lm -lpthread -lbsd				\
+	-lm -lpthread					\
+	$(libfwts_LDADD_BSD)				\
 	@GIO_LIBS@					\
 	@GLIB_LIBS@
 

--- a/src/lib/src/fwts_battery.c
+++ b/src/lib/src/fwts_battery.c
@@ -25,10 +25,13 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <string.h>
-#include <bsd/string.h>
 #include <limits.h>
 #include <dirent.h>
 #include <inttypes.h>
+
+#ifdef HAVE_BSD_STRING_H
+#include <bsd/string.h>
+#endif
 
 static inline bool fwts_battery_match(
 	const uint32_t index,

--- a/src/lib/src/fwts_button.c
+++ b/src/lib/src/fwts_button.c
@@ -26,7 +26,10 @@
 #include <string.h>
 #include <limits.h>
 #include <dirent.h>
+
+#ifdef HAVE_BSD_STRING_H
 #include <bsd/string.h>
+#endif
 
 #define FWTS_PROC_ACPI_BUTTON	"/proc/acpi/button"
 

--- a/src/lib/src/fwts_framework.c
+++ b/src/lib/src/fwts_framework.c
@@ -26,12 +26,15 @@
 #include <ctype.h>
 #include <time.h>
 #include <getopt.h>
-#include <bsd/string.h>
 #include <sys/utsname.h>
 #include <sys/time.h>
 
 #include "fwts.h"
 #include "fwts_pm_method.h"
+
+#ifdef HAVE_BSD_STRING_H
+#include <bsd/string.h>
+#endif
 
 typedef struct {
 	const char *title;		/* Test category */

--- a/src/lib/src/fwts_hwinfo.c
+++ b/src/lib/src/fwts_hwinfo.c
@@ -20,7 +20,6 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <string.h>
-#include <bsd/string.h>
 #include <errno.h>
 #include <inttypes.h>
 #include <dirent.h>
@@ -36,6 +35,10 @@
 #include <arpa/inet.h>
 
 #include "fwts.h"
+
+#ifdef HAVE_BSD_STRING_H
+#include <bsd/string.h>
+#endif
 
 #define FWTS_HWINFO_LISTS_SAME		(0)
 #define FWTS_HWINFO_LISTS_DIFFER	(1)

--- a/src/lib/src/fwts_kernel.c
+++ b/src/lib/src/fwts_kernel.c
@@ -23,7 +23,10 @@
 #include "fwts_kernel.h"
 #include <stdlib.h>
 #include <stdio.h>
+
+#ifdef HAVE_BSD_STRING_H
 #include <bsd/string.h>
+#endif
 
 #define CONFIG_FILE_PREFIX	"/boot/config-"
 #define CONFIG_FILE_PROC	"/proc/config.gz"

--- a/src/lib/src/fwts_modprobe.c
+++ b/src/lib/src/fwts_modprobe.c
@@ -28,9 +28,12 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <sys/utsname.h>
-#include <bsd/string.h>
 
 #include "fwts.h"
+
+#ifdef HAVE_BSD_STRING_H
+#include <bsd/string.h>
+#endif
 
 /*
  *  fwts_module_path()


### PR DESCRIPTION
strlcpy() and strlcat() are available in the glibc since version 2.38:
    
     https://lists.gnu.org/archive/html/info-gnu/2023-07/msg00010.html

So to ease compilation on systems that have at least glibc 2.38, but do not have libbsd, let's detect whether fwts can be used without libbsd and make it optional for that case.