### PR TITLE
build: link to zlib

### DIFF
--- a/src/lib/src/Makefile.am
+++ b/src/lib/src/Makefile.am
@@ -35,7 +35,7 @@ libfwts_LDADD_BSD = -lbsd
 endif
 
 libfwts_la_LIBADD = 				\
-	-lm -lpthread					\
+	-lm -lpthread -lz				\
 	$(libfwts_LDADD_BSD)				\
 	@GIO_LIBS@					\
 	@GLIB_LIBS@


### PR DESCRIPTION
zlib is used by the library but never explicitly linked.

For example there is a call to `gzopen` in `src/lib/src/fwts_fileio.c`

For context, this is at least required in:

- nixos https://github.com/NixOS/nixpkgs/pull/522269
- openbmc also has a patch to fix this https://github.com/openbmc/openbmc/blob/7afa8803b803635f8eb6411e7e6ca63703b9d62e/upstream-layers/meta-openembedded/meta-oe/recipes-test/fwts/fwts/0001-Makefile.am-Add-missing-link-with-zlib.patch