### PR TITLE
dmi: dmicheck: fix bus error when copying SMBIOS tables from memory

### DIFF
--- a/src/dmi/dmicheck/dmicheck.c
+++ b/src/dmi/dmicheck/dmicheck.c
@@ -442,8 +442,12 @@ static void* dmi_table_smbios(fwts_framework *fw, fwts_smbios_entry *entry)
 			return NULL;
 		}
 		table = malloc(length);
-		if (table)
-			memcpy(table, mem, length);
+		if (table && fwts_safe_memcpy(table, mem, length) != FWTS_OK) {
+			fwts_log_info(fw, "SMBIOS table at %p cannot be read", (void *)addr);
+			free(table);
+			(void)fwts_munmap(mem, length);
+			return NULL;
+		}
 		(void)fwts_munmap(mem, length);
 		return table;
 	}
@@ -498,8 +502,12 @@ static void* dmi_table_smbios30(fwts_framework *fw, fwts_smbios30_entry *entry)
 			return NULL;
 		}
 		table = malloc(length);
-		if (table)
-			memcpy(table, mem, length);
+		if (table && fwts_safe_memcpy(table, mem, length) != FWTS_OK) {
+			fwts_log_info(fw, "SMBIOS table at %p cannot be read", (void *)addr);
+			free(table);
+			(void)fwts_munmap(mem, length);
+			return NULL;
+		}
 		(void)fwts_munmap(mem, length);
 		return table;
 	}


### PR DESCRIPTION
## Summary

Fixes [#39](https://github.com/fwts/fwts/issues/39) — a bus error (SIGBUS) on arm64 when `dmicheck` reads SMBIOS tables from memory.

## Problem

When the SMBIOS entry tables are not available via sysfs, `dmicheck` falls back to `mmap`'ing them from `/dev/mem` and copying them out with `memcpy()`. This in-memory path is only reached on arm64 when `CONFIG_STRICT_DEVMEM` is **not** set (otherwise the existing guard bails out early).

On arm64 the firmware region is mapped as **Device memory**, which does not allow unaligned accesses. glibc's optimized `memcpy()` uses wide/unaligned/vector loads, so the copy triggers an alignment fault and the process dies with **SIGBUS**.

The preceding `fwts_safe_memread()` check passes because it reads the region strictly byte-by-byte, so the crash only surfaces in the following `memcpy()`.

## Fix

Use `fwts_safe_memcpy()` instead, which is compiled with `OPTIMIZE0` and copies one byte at a time (so accesses stay aligned) while trapping SIGBUS/SIGSEGV. On failure it logs, frees the buffer, unmaps and returns NULL instead of crashing — matching the convention already used in `fwts_smbios.c` and `fwts_acpi_tables.c`.

Applied to both `dmi_table_smbios()` (SMBIOS 2.x) and `dmi_table_smbios30()` (SMBIOS 3.0).